### PR TITLE
Fix the init failure due to too small delay time after reset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # ESP LCD Touch FT6x36 Controller
 
-[![Component Registry](https://components.espressif.com/components/espressif/esp_lcd_touch_ft6x36/badge.svg)](https://components.espressif.com/components/cfscn/esp_lcd_touch_ft6x36)
+[![Component Registry](https://components.espressif.com/components/cfscn/esp_lcd_touch_ft6x36/badge.svg)](https://components.espressif.com/components/cfscn/esp_lcd_touch_ft6x36)
 
 This repository is forked from espressif/esp_lcd_touch_ft5x06
 
 Implementation of the FT6x36 touch controller with esp_lcd_touch component.
 
-| Touch controller | Communication interface | Component name | Link to datasheet |
-| :--------------: | :---------------------: | :------------: | :---------------: |
-| FT6x36           | I2C                     | esp_lcd_touch_ft6x36 | [PDF](https://www.buydisplay.com/download/ic/FT6236-FT6336-FT6436L-FT6436_Datasheet.pdf) |
+| Touch controller | Communication interface |    Component name    |                                    Link to datasheet                                     |
+| :--------------: | :---------------------: | :------------------: | :--------------------------------------------------------------------------------------: |
+|      FT6x36      |           I2C           | esp_lcd_touch_ft6x36 | [PDF](https://www.buydisplay.com/download/ic/FT6236-FT6336-FT6436L-FT6436_Datasheet.pdf) |
 
 [^1]: **NOTE:** This controller should work via I2C or SPI communication interface. But it was tested on HW only via I2C communication interface.
 
@@ -17,7 +17,7 @@ Implementation of the FT6x36 touch controller with esp_lcd_touch component.
 Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).
 You can add them to your project via `idf.py add-dependancy`, e.g.
 ```
-    idf.py add-dependency esp_lcd_touch_ft6x36==1.0.0
+    idf.py add-dependency esp_lcd_touch_ft6x36==1.0.9
 ```
 
 Alternatively, you can create `idf_component.yml`. More is in [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html).
@@ -26,8 +26,9 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 I2C initialization of the touch component.
 
-```
-    esp_lcd_panel_io_i2c_config_t io_config = ESP_LCD_TOUCH_IO_I2C_FT6x36_CONFIG();
+```c
+    CLK_SPEED = 400 * 1000;
+    esp_lcd_panel_io_i2c_config_t io_config = ESP_LCD_TOUCH_IO_I2C_FT6x36_CONFIG(CLK_SPEED);
 
     esp_lcd_touch_config_t tp_cfg = {
         .x_max = CONFIG_LCD_HRES,

--- a/esp_lcd_touch_ft6x36.c
+++ b/esp_lcd_touch_ft6x36.c
@@ -329,9 +329,9 @@ static esp_err_t touch_ft6x36_reset(esp_lcd_touch_handle_t tp)
     if (tp->config.rst_gpio_num != GPIO_NUM_NC)
     {
         ESP_RETURN_ON_ERROR(gpio_set_level(tp->config.rst_gpio_num, tp->config.levels.reset), TAG, "GPIO set level error!");
-        vTaskDelay(pdMS_TO_TICKS(10));
+        vTaskDelay(pdMS_TO_TICKS(50));
         ESP_RETURN_ON_ERROR(gpio_set_level(tp->config.rst_gpio_num, !tp->config.levels.reset), TAG, "GPIO set level error!");
-        vTaskDelay(pdMS_TO_TICKS(10));
+        vTaskDelay(pdMS_TO_TICKS(150));
     }
 
     return ESP_OK;

--- a/include/esp_lcd_touch_ft6x36.h
+++ b/include/esp_lcd_touch_ft6x36.h
@@ -42,17 +42,18 @@ extern "C"
  * @brief Touch IO configuration structure
  *
  */
-#define ESP_LCD_TOUCH_IO_I2C_FT6x36_CONFIG()             \
+#define ESP_LCD_TOUCH_IO_I2C_FT6x36_CONFIG(CLK_SPEED)    \
     {                                                    \
         .dev_addr = ESP_LCD_TOUCH_IO_I2C_FT6x36_ADDRESS, \
         .control_phase_bytes = 1,                        \
         .dc_bit_offset = 0,                              \
         .lcd_cmd_bits = 8,                               \
-        .flags =                                         \
-        {                                                \
-            .disable_control_phase = 1,                  \
-        }                                                \
+        .scl_speed_hz = CLK_SPEED,
+    .flags =
+        {
+            .disable_control_phase = 1,
     }
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
代码很规范
我根据我在ft6336和esp32s3上的使用情况，适当增加了重置后的延时时间，最低需要100ms，再短可能就会在读取寄存器测试时失败。
另外还增加了一个宏参数方便直接调整 iic的时钟速率。
<img width="2863" height="696" alt="image" src="https://github.com/user-attachments/assets/6578595b-2b18-4aba-a900-f50275b24dcd" />
